### PR TITLE
Custom tests for different style logins

### DIFF
--- a/.github/workflows/api-auth-tests.yml
+++ b/.github/workflows/api-auth-tests.yml
@@ -45,7 +45,7 @@ jobs:
         timeout-minutes: 3
 
       - name: Run the API authentication tests
-        run: uv run pytest -n 2 -m "api" tests/api/test_auth_api.py
+        run: uv run pytest -n 7 -m "api" tests/api/test_auth_api.py
         env:
           DISPLAY: :1
           HOST: http://localhost:8000

--- a/tests/acme_corp/acme_corp.py
+++ b/tests/acme_corp/acme_corp.py
@@ -24,10 +24,64 @@ def index() -> Any:
             Main(
                 H1("ACME Corp"),
                 Ul(
+                    Li(A("Email and Password", href="/auth/email-and-password")),
+                ),
+                Ul(
+                    Li(A("Email then Password", href="/auth/email-then-password")),
+                ),
+                Ul(
+                    Li(
+                        A("Email then Password then MFA", href="/auth/email-then-password-then-mfa")
+                    ),
+                ),
+                Ul(
+                    Li(
+                        A(
+                            "Email and Password in Overlay component",
+                            href="/auth/email-password-overlay",
+                        )
+                    ),
+                ),
+                Ul(
+                    Li(A("Email then OTP", href="/auth/email-then-otp")),
+                ),
+                Ul(
+                    Li(
+                        A(
+                            "Email then OTP with Multi Inputs",
+                            href="/auth/email-then-otp-multi-inputs",
+                        )
+                    ),
+                ),
+                Ul(
                     Li(
                         A(
                             "Email and Password with Checkbox",
                             href="/auth/email-and-password-checkbox",
+                        )
+                    ),
+                ),
+                Ul(
+                    Li(
+                        A(
+                            "Email then Password with Long Delay",
+                            href="/auth/email-then-password-long-delay",
+                        )
+                    ),
+                ),
+                Ul(
+                    Li(
+                        A(
+                            "Email and Password Overlay with Hidden Last Name",
+                            href="/auth/email-password-lastname-overlay",
+                        )
+                    ),
+                ),
+                Ul(
+                    Li(
+                        A(
+                            "Sign-in Error Test (Universal Page)",
+                            href="/universal-error-test",
                         )
                     ),
                 ),

--- a/tests/acme_corp/email_and_password.py
+++ b/tests/acme_corp/email_and_password.py
@@ -1,0 +1,45 @@
+# ---------------------------------------------------------------------------
+# Email + password
+# ---------------------------------------------------------------------------
+import random
+import time
+
+from fasthtml.common import (
+    H1,
+    Body,
+    Head,
+    Html,
+    Main,
+    P,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.constants import (
+    MAX_TIME_DELAY,
+    MIN_TIME_DELAY,
+    VALID_EMAIL,
+    VALID_PASSWORD,
+)
+from tests.acme_corp.helpers import (
+    create_email_password_form,
+    welcome_page,
+)
+
+
+@app.get("/auth/email-and-password")
+def login_form():
+    return create_email_password_form(show_remember_me=False)
+
+
+@app.post("/submit/email-and-password")
+def login_submit(email: str, password: str):
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if email == VALID_EMAIL and password == VALID_PASSWORD:
+        return welcome_page(email)
+
+    return create_email_password_form(
+        "You have entered an invalid email or password", show_remember_me=False
+    )

--- a/tests/acme_corp/email_password_lastname_overlay.py
+++ b/tests/acme_corp/email_password_lastname_overlay.py
@@ -1,0 +1,131 @@
+import random
+import time
+
+from fasthtml.common import (
+    H1,
+    Body,
+    Button,
+    Div,
+    Form,
+    Head,
+    Html,
+    Input,
+    Label,
+    Main,
+    P,
+    Script,
+    Style,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.constants import (
+    MAX_TIME_DELAY,
+    MIN_TIME_DELAY,
+    VALID_EMAIL,
+    VALID_LASTNAME,
+    VALID_PASSWORD,
+)
+from tests.acme_corp.helpers import welcome_page
+
+
+def create_overlay_form(error_message: str = None):
+    """Create an overlay form with email, last name, and password fields."""
+    form_fields = [
+        Label("Email:", Input(type="email", name="email", id="email", required=True)),
+        Div(
+            Label("Last Name:", Input(type="text", name="lastname", required=True)),
+            id="lastnameField",
+            style="display: none;",
+        ),
+        Label("Password:", Input(type="password", name="password", required=True)),
+        Button("Sign in", type="submit"),
+    ]
+
+    if error_message:
+        form_fields.append(Div(P(f"❌ {error_message}"), cls="feedback-message"))
+
+    return Div(
+        Form(
+            *form_fields,
+            action="/submit/email-password-lastname-overlay",
+            method="post",
+            cls="overlay-form",
+        ),
+        id="loginOverlay",
+        cls="overlay",
+    )
+
+
+@app.get("/auth/email-password-lastname-overlay")
+def overlay_login_page():
+    """Render the main page with a button that triggers the login overlay."""
+    styles = """
+        .overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            justify-content: center;
+            align-items: center;
+        }
+        .overlay-form {
+            background: white;
+            padding: 2rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        .overlay.active {
+            display: flex;
+        }
+        #lastnameField {
+            transition: opacity 0.3s ease;
+        }
+    """
+
+    script = """
+        function toggleOverlay() {
+            document.getElementById('loginOverlay').classList.toggle('active');
+        }
+        
+        document.addEventListener('DOMContentLoaded', function() {
+            const emailInput = document.getElementById('email');
+            const lastnameField = document.getElementById('lastnameField');
+            
+            emailInput.addEventListener('input', function() {
+                if (this.value.trim() !== '') {
+                    lastnameField.style.display = 'block';
+                } else {
+                    lastnameField.style.display = 'none';
+                }
+            });
+        });
+    """
+
+    return Html(
+        Head(Title("ACME Corp - Overlay Login"), Style(styles), picolink),
+        Body(
+            Main(
+                H1("Welcome to ACME Corp"),
+                Button("Sign in", onclick="toggleOverlay()"),
+                create_overlay_form(),
+                cls="container",
+            ),
+            Script(script),
+        ),
+    )
+
+
+@app.post("/submit/email-password-lastname-overlay")
+def overlay_login_submit(email: str, lastname: str, password: str):
+    """Handle the login form submission."""
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if email == VALID_EMAIL and password == VALID_PASSWORD and lastname == VALID_LASTNAME:
+        return welcome_page(email)
+
+    return overlay_login_page()

--- a/tests/acme_corp/email_password_overlay.py
+++ b/tests/acme_corp/email_password_overlay.py
@@ -1,0 +1,109 @@
+# ---------------------------------------------------------------------------
+# Email + password + overlay
+# ---------------------------------------------------------------------------
+import random
+import time
+
+from fasthtml.common import (
+    H1,
+    Body,
+    Button,
+    Div,
+    Form,
+    Head,
+    Html,
+    Input,
+    Label,
+    Main,
+    P,
+    Script,
+    Style,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.constants import (
+    MAX_TIME_DELAY,
+    MIN_TIME_DELAY,
+    VALID_EMAIL,
+    VALID_PASSWORD,
+)
+from tests.acme_corp.helpers import welcome_page
+
+
+def create_overlay_form(error_message: str = None):
+    """Create an overlay form with email and password fields."""
+    form_fields = [
+        Label("Email:", Input(type="email", name="email", required=True)),
+        Label("Password:", Input(type="password", name="password", required=True)),
+        Button("Sign in", type="submit"),
+    ]
+
+    if error_message:
+        form_fields.append(Div(P(f"❌ {error_message}"), cls="feedback-message"))
+
+    return Div(
+        Form(
+            *form_fields, action="/submit/email-password-overlay", method="post", cls="overlay-form"
+        ),
+        id="loginOverlay",
+        cls="overlay",
+    )
+
+
+@app.get("/auth/email-password-overlay")
+def overlay_login_page():
+    """Render the main page with a button that triggers the login overlay."""
+    styles = """
+        .overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            justify-content: center;
+            align-items: center;
+        }
+        .overlay-form {
+            background: white;
+            padding: 2rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        .overlay.active {
+            display: flex;
+        }
+    """
+
+    script = """
+        function toggleOverlay() {
+            document.getElementById('loginOverlay').classList.toggle('active');
+        }
+    """
+
+    return Html(
+        Head(Title("ACME Corp - Overlay Login"), Style(styles), picolink),
+        Body(
+            Main(
+                H1("Welcome to ACME Corp"),
+                Button("Sign in", onclick="toggleOverlay()"),
+                create_overlay_form(),
+                cls="container",
+            ),
+            Script(script),
+        ),
+    )
+
+
+@app.post("/submit/email-password-overlay")
+def overlay_login_submit(email: str, password: str):
+    """Handle the login form submission."""
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if email == VALID_EMAIL and password == VALID_PASSWORD:
+        return welcome_page(email)
+
+    return overlay_login_page()

--- a/tests/acme_corp/email_then_otp.py
+++ b/tests/acme_corp/email_then_otp.py
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------
+# Email -> OTP
+# ---------------------------------------------------------------------------
+
+import random
+import time
+
+from fasthtml.common import (
+    H1,
+    Body,
+    Head,
+    Html,
+    Main,
+    P,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.constants import (
+    MAX_TIME_DELAY,
+    MIN_TIME_DELAY,
+    VALID_EMAIL,
+    VALID_OTP,
+)
+from tests.acme_corp.helpers import (
+    create_email_form,
+    create_otp_form,
+    welcome_page,
+)
+
+
+@app.get("/auth/email-then-otp")
+def email_otp_form():
+    return create_email_form(action="/auth/email-then-otp")
+
+
+@app.post("/auth/email-then-otp")
+def check_email_from_otp(email: str):
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if email != VALID_EMAIL:
+        return create_email_form(
+            "Error occurred",
+            action="/auth/email-then-otp",
+        )
+
+    return create_otp_form(email, action="/submit/email-then-otp/login")
+
+
+@app.post("/submit/email-then-otp/login")
+def check_otp(email: str, otp: str):
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if email == VALID_EMAIL and otp == VALID_OTP:
+        return welcome_page(email)
+
+    return create_otp_form(email, "Incorrect credentials")

--- a/tests/acme_corp/email_then_otp_multi_inputs.py
+++ b/tests/acme_corp/email_then_otp_multi_inputs.py
@@ -1,0 +1,59 @@
+# ---------------------------------------------------------------------------
+# Email -> OTP
+# ---------------------------------------------------------------------------
+
+import random
+import time
+
+from fasthtml.common import (
+    H1,
+    Body,
+    Head,
+    Html,
+    Main,
+    P,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.constants import (
+    MAX_TIME_DELAY,
+    MIN_TIME_DELAY,
+    VALID_EMAIL,
+    VALID_OTP,
+)
+from tests.acme_corp.helpers import (
+    create_email_form,
+    create_otp_form,
+    handle_email_validation,
+    welcome_page,
+)
+
+
+@app.get("/auth/email-then-otp-multi-inputs")
+def email_otp_form():
+    return create_email_form(action="/auth/email-then-otp-multi-inputs")
+
+
+@app.post("/auth/email-then-otp-multi-inputs")
+def check_email_from_otp(email: str):
+    return handle_email_validation(
+        email,
+        error_form_action="/auth/email-then-otp-multi-inputs",
+        error_message="Invalid email address",
+        success_callback=lambda email: create_otp_form(
+            email, action="/submit/email-then-otp-multi-inputs/login", multi_inputs=True
+        ),
+        use_random_delay=True,
+    )
+
+
+@app.post("/submit/email-then-otp-multi-inputs/login")
+def check_otp(email: str, otp: str):
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if email == VALID_EMAIL and otp == VALID_OTP:
+        return welcome_page(email)
+
+    return create_otp_form(email, "Incorrect credentials")

--- a/tests/acme_corp/email_then_pass_then_mfa.py
+++ b/tests/acme_corp/email_then_pass_then_mfa.py
@@ -1,0 +1,105 @@
+# --------------------------------------------------------------
+# Email -> password -> MFA
+# --------------------------------------------------------------
+import time
+import random
+
+from fasthtml.common import (
+    Input,
+    Button,
+    Label,
+)
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.constants import (
+    VALID_EMAIL,
+    VALID_PASSWORD,
+    VALID_OTP,
+    MIN_TIME_DELAY,
+    MAX_TIME_DELAY,
+)
+from tests.acme_corp.helpers import render_form, email_fields, welcome_page
+
+
+@app.get("/auth/email-then-password-then-mfa")
+def show_email_form():
+    return render_form(
+        fields=email_fields,
+        action="/submit/email-then-password-then-mfa/email",
+    )
+
+
+@app.post("/submit/email-then-password-then-mfa/email")
+def handle_email(email: str):
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if email != VALID_EMAIL:
+        return render_form(
+            email_fields,
+            "/submit/email-then-password-then-mfa/email",
+            error_message="Unknown email",
+        )
+
+    password_fields = [
+        Input(type="hidden", name="email", value=email),
+        Label("Password:", Input(type="password", name="password", autofocus=True, required=True)),
+        Button("Continue", type="submit"),
+    ]
+    return render_form(password_fields, "/submit/email-then-password-then-mfa/password")
+
+
+@app.post("/submit/email-then-password-then-mfa/password")
+def handle_password(email: str, password: str):
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if password != VALID_PASSWORD:
+        return render_form(
+            [
+                Input(type="hidden", name="email", value=email),
+                Label(
+                    "Password:",
+                    Input(type="password", name="password", autofocus=True, required=True),
+                ),
+                Button("Continue", type="submit"),
+            ],
+            "/submit/email-then-password-then-mfa/password",
+            button="Continue",
+            error_message="Incorrect password",
+        )
+
+    mfa_fields = [
+        Input(type="hidden", name="email", value=email),
+        Input(type="hidden", name="password", value=password),
+        Label(
+            "One-time code:",
+            Input(
+                type="text", name="otp", autofocus=True, autocomplete="one-time-code", required=True
+            ),
+        ),
+        Button("Verify", type="submit"),
+    ]
+    return render_form(mfa_fields, "/submit/email-then-password-then-mfa/otp")
+
+
+@app.post("/submit/email-then-password-then-mfa/otp")
+def handle_otp(email: str, password: str, otp: str):
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if otp == VALID_OTP and email == VALID_EMAIL and password == VALID_PASSWORD:
+        return welcome_page(email)
+
+    mfa_fields = [
+        Input(type="hidden", name="email", value=email),
+        Input(type="hidden", name="password", value=password),
+        Label(
+            "One-time code:",
+            Input(
+                type="text", name="otp", autofocus=True, autocomplete="one-time-code", required=True
+            ),
+        ),
+    ]
+    return render_form(
+        mfa_fields,
+        "/submit/email-then-password-then-mfa/otp",
+        button="Verify",
+        error_message="Invalid code",
+    )

--- a/tests/acme_corp/email_then_password.py
+++ b/tests/acme_corp/email_then_password.py
@@ -1,0 +1,63 @@
+# ---------------------------------------------------------------------------
+# Email -> password
+# ---------------------------------------------------------------------------
+import random
+import time
+
+from fasthtml.common import (
+    H1,
+    Body,
+    Button,
+    Head,
+    Html,
+    Input,
+    Label,
+    Main,
+    P,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.constants import (
+    MAX_TIME_DELAY,
+    MIN_TIME_DELAY,
+    VALID_EMAIL,
+    VALID_PASSWORD,
+)
+from tests.acme_corp.helpers import (
+    create_email_form,
+    create_password_form,
+    handle_email_validation,
+    password_form_callback,
+    welcome_page,
+)
+
+
+@app.get("/auth/email-then-password")
+def email_form():
+    # First page: email entry; form submits back to the same /auth route.
+    return create_email_form(action="/auth/email-then-password")
+
+
+@app.post("/auth/email-then-password")
+def check_email(email: str):
+    return handle_email_validation(
+        email,
+        error_form_action="/auth/email-then-password",
+        error_message="Unrecognized email",
+        success_callback=password_form_callback("/submit/email-then-password/login"),
+        use_random_delay=True,
+    )
+
+
+@app.post("/submit/email-then-password/login")
+def check_password(email: str, password: str):
+    time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    if email == VALID_EMAIL and password == VALID_PASSWORD:
+        return welcome_page(email)
+
+    return create_password_form(
+        email, "Incorrect credentials", action="/submit/email-then-password/login"
+    )

--- a/tests/acme_corp/email_then_password_long_delay.py
+++ b/tests/acme_corp/email_then_password_long_delay.py
@@ -1,0 +1,61 @@
+# ---------------------------------------------------------------------------
+# Email -> password
+# ---------------------------------------------------------------------------
+import time
+
+from fasthtml.common import (
+    H1,
+    Body,
+    Button,
+    Head,
+    Html,
+    Input,
+    Label,
+    Main,
+    P,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.constants import (
+    VALID_EMAIL,
+    VALID_PASSWORD,
+)
+from tests.acme_corp.helpers import (
+    create_email_form,
+    create_password_form,
+    handle_email_validation,
+    password_form_callback,
+    welcome_page,
+)
+
+
+@app.get("/auth/email-then-password-long-delay")
+def email_form():
+    # Display initial email form; post back to the same /auth route.
+    return create_email_form(action="/auth/email-then-password-long-delay")
+
+
+@app.post("/auth/email-then-password-long-delay")
+def check_email(email: str):
+    """Validate the submitted e-mail for the long-delay demo."""
+    return handle_email_validation(
+        email,
+        error_form_action="/auth/email-then-password-long-delay",
+        error_message="Unknown email",
+        success_callback=password_form_callback("/submit/email-then-password/login"),
+        delay_seconds=15,
+        use_random_delay=False,
+    )
+
+
+@app.post("/submit/email-then-password-long-delay/login")
+def check_password(email: str, password: str):
+    time.sleep(15)
+
+    if email == VALID_EMAIL and password == VALID_PASSWORD:
+        return welcome_page(email)
+    return create_password_form(
+        email, "Incorrect credentials", action="/submit/email-then-password/login"
+    )

--- a/tests/acme_corp/email_validation_and_password.py
+++ b/tests/acme_corp/email_validation_and_password.py
@@ -1,0 +1,43 @@
+# ---------------------------------------------------------------------------
+# Email validation and password
+# ---------------------------------------------------------------------------
+import random
+import time
+
+from fasthtml.common import (
+    H1,
+    Body,
+    Head,
+    Html,
+    Main,
+    P,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.constants import (
+    MAX_TIME_DELAY,
+    MIN_TIME_DELAY,
+    VALID_EMAIL,
+    VALID_PASSWORD,
+)
+from tests.acme_corp.helpers import (
+    create_email_password_form,
+    welcome_page,
+)
+
+
+@app.get("/auth/email-validation-and-password")
+def login_form():
+    return create_email_password_form(show_remember_me=False, email_validation=True)
+
+
+@app.post("/submit/email-validation-and-password")
+def login_submit(email: str, password: str):
+    if email == VALID_EMAIL and password == VALID_PASSWORD:
+        return welcome_page(email)
+
+    return create_email_password_form(
+        "You have entered an invalid email or password", show_remember_me=False
+    )

--- a/tests/acme_corp/helpers.py
+++ b/tests/acme_corp/helpers.py
@@ -24,7 +24,7 @@ from fasthtml.common import (
     picolink,
 )
 
-from tests.acme_corp.constants import VALID_EMAIL
+from tests.acme_corp.constants import VALID_EMAIL, MIN_TIME_DELAY, MAX_TIME_DELAY, VALID_OTP
 
 
 def create_email_password_form(
@@ -110,6 +110,206 @@ def welcome_page(email: str):
                 H1("Login successful!"),
                 P(f"Welcome, {email}.", cls="feedback-message"),
                 P(A("Home Page", href="/"), cls="home-link"),
+                cls="container",
+            )
+        ),
+    )
+
+email_fields: list[Union[Label, Input, Button]] = [ # noqa
+    Label(
+        "Email:",
+        Input(
+            type="email",
+            name="email",
+            autofocus=True,
+            autocomplete="email",
+            required=True,
+        ),
+    ),
+    Button("Continue", type="submit"),
+]
+
+def create_email_form(
+    error_message: str | None = None, action: str = "/submit/email-then-password/next"
+):
+    """First page in the two-step flow (email → password)."""
+    return render_form(email_fields, action=action, error_message=error_message)
+
+def create_otp_form(
+    email: str, action: str, *, error_message: str | None = None, multi_inputs: bool = False
+):
+    """Second page in the two-step flow (password entry)."""
+    if multi_inputs:
+        otp_input = Label(
+            "One-time code:",
+            Div(
+                *[
+                    Input(
+                        type="text",
+                        name=f"otp_{i + 1}",
+                        maxlength=1,
+                        required=False,
+                    )
+                    for i in range(len(VALID_OTP))
+                ],
+                cls="grid",
+            ),
+            Input(type="text", name="otp", hidden=True),
+        )
+    else:
+        otp_input = Label(
+            "One-time code:",
+            Input(type="text", name="otp", autofocus=True, required=True),
+        )
+
+    fields = [
+        Input(type="email", name="email", hidden=True, required=True, value=email),
+        otp_input,
+        Button("Log in", type="submit"),
+    ]
+    script = """
+        document.addEventListener('DOMContentLoaded', function() {
+            const form = document.querySelector('form');
+            const otpDigitInputs = document.querySelectorAll('input[name^="otp_"]');
+            
+            // Auto-focus and navigation logic
+            otpDigitInputs.forEach((input, index) => {
+                if (index === 0) input.focus();
+                
+                input.addEventListener('input', function(e) {
+                    // Only allow numbers
+                    this.value = this.value.replace(/[^0-9]/g, '');
+                    
+                    // Auto-advance to next input
+                    if (this.value.length === 1 && index < otpDigitInputs.length - 1) {
+                        otpDigitInputs[index + 1].focus();
+                    }
+                });
+                
+                input.addEventListener('keydown', function(e) {
+                    // Handle backspace navigation
+                    if (e.key === 'Backspace' && this.value === '' && index > 0) {
+                        otpDigitInputs[index - 1].focus();
+                    }
+                });
+            });
+            
+            // Merge OTP inputs before form submission
+            form.addEventListener('submit', function(e) {
+                let otpInput = form.querySelector('input[name="otp"]');
+                if (otpDigitInputs.length > 0) {  // multi-inputs case
+                    const otpValues = Array.from(otpDigitInputs).map(input => input.value).join('');
+                    otpInput.value = otpValues;
+                    
+                    // Remove individual OTP inputs from form submission
+                    otpDigitInputs.forEach(input => input.disabled = true);
+                } // single-input case
+            });
+        });
+    """
+    return render_form(
+        fields,
+        action=action,
+        error_message=error_message,
+        script=script,
+    )
+
+
+def create_password_form(
+    email: str, error_message: str | None = None, action: str = "/submit/email-then-password/login"
+):
+    """Second page in the two-step flow (password entry)."""
+    fields = [
+        Input(
+            type="email",
+            name="email",
+            hidden=True,
+            required=True,
+            value=email,
+        ),
+        Label(
+            "Password:",
+            Input(
+                type="password",
+                name="password",
+                autofocus=True,
+                required=True,
+            ),
+        ),
+        Button("Log in", type="submit"),
+    ]
+    return render_form(
+        fields,
+        action=action,
+        error_message=error_message,
+    )
+
+def handle_email_validation(
+    email: str,
+    *,
+    error_form_action: str,
+    error_message: str = "Invalid email address",
+    success_callback: Callable[[str], any],
+    delay_seconds: float | None = None,
+    use_random_delay: bool = True,
+):
+    """
+    Handle common email validation pattern across different routes.
+
+    Args:
+        email: The email to validate
+        error_form_action: The action URL for the error form
+        error_message: Custom error message for invalid email
+        success_callback: Function to call on successful validation (receives email)
+        delay_seconds: Fixed delay in seconds (overrides random delay)
+        use_random_delay: Whether to use random delay (ignored if delay_seconds is set)
+
+    Returns:
+        Either error form or result from success_callback
+    """
+    # Handle delay
+    if delay_seconds is not None:
+        time.sleep(delay_seconds)
+    elif use_random_delay:
+        time.sleep(random.uniform(MIN_TIME_DELAY, MAX_TIME_DELAY))
+
+    # Validate email
+    if email != VALID_EMAIL:
+        return create_email_form(
+            action=error_form_action,
+            error_message=error_message,
+        )
+
+    # Call success callback with the validated email
+    return success_callback(email)
+
+# Common success callback factories for typical patterns
+def password_form_callback(action: str):
+    """Factory function for creating password form callbacks."""
+
+    def callback(email: str):
+        return create_password_form(email, action=action)
+
+    return callback
+
+def signin_page(action: str = "/error-page"):
+    """Simple sign-in page that navigates to error page when submitted."""
+    return Html(
+        Head(Title("ACME Corp - Sign In Test"), picolink),
+        Body(
+            Main(
+                H1("🏢 ACME Corp Sign In"),
+                P("Click 'Sign In' to continue"),
+                Form(
+                    Button(
+                        "Sign In",
+                        type="submit",
+                        style="width: auto; padding: 0.5rem 1rem;",
+                        **{"data-testid": "signin-button"},
+                    ),
+                    action=action,
+                    method="post",
+                ),
                 cls="container",
             )
         ),

--- a/tests/acme_corp/navigate_to_verify.py
+++ b/tests/acme_corp/navigate_to_verify.py
@@ -1,0 +1,27 @@
+from fasthtml.common import (
+    H1,
+    Body,
+    Head,
+    Html,
+    Main,
+    P,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+
+
+@app.get("/verify")
+def verify_account():
+    """Return the verification page after successful login."""
+    return Html(
+        Head(Title("ACME Corp - Account Verification"), picolink),
+        Body(
+            Main(
+                H1("Account Status"),
+                P("Account verified", cls="feedback-message"),
+                cls="container",
+            )
+        ),
+    )

--- a/tests/acme_corp/universal_error_page.py
+++ b/tests/acme_corp/universal_error_page.py
@@ -1,0 +1,51 @@
+"""
+ACME Corp Sign-in Error Page Extension
+
+Simple test endpoints for testing universal error page detection.
+Uses fasthtml like other ACME test files.
+"""
+
+from fasthtml.common import (
+    H1,
+    Body,
+    Button,
+    Div,
+    Form,
+    Head,
+    Html,
+    Input,
+    Label,
+    Main,
+    P,
+    Title,
+    picolink,
+)
+
+from tests.acme_corp.acme_corp import app
+from tests.acme_corp.helpers import signin_page
+
+
+@app.get("/universal-error-test")
+def signin_error_page():
+    return signin_page("/error-page")
+
+
+@app.post("/error-page")
+def error_page(username: str = "", password: str = ""):
+    """Error page that should be detected as a universal error page."""
+    return Html(
+        Head(Title("ACME Corp - Error"), picolink),
+        Body(
+            Main(
+                Div(
+                    H1("⚠️ Authentication Error"),
+                    P("This is a test error page for universal error detection."),
+                    Div(
+                        P(f"Error Code: ACME_AUTH_ERROR_001"),
+                        style="background: #f8f9fa; padding: 1rem; border-radius: 4px; margin: 1rem 0;",
+                    ),
+                ),
+                cls="container",
+            )
+        ),
+    )

--- a/tests/api/test_auth_api.py
+++ b/tests/api/test_auth_api.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 import requests
-from tests.acme_corp.constants import VALID_EMAIL, VALID_PASSWORD
+from tests.acme_corp.constants import VALID_EMAIL, VALID_PASSWORD, VALID_LASTNAME, VALID_OTP
 
 HOST = os.environ.get("HOST", "http://localhost:8000")
 API_KEY = os.environ.get("API_KEY")
@@ -11,7 +11,19 @@ API_KEY = os.environ.get("API_KEY")
 TEST_CASES = [
     # Simple tests
     {"test": "cnn"},
+    {"test": "acme-email-and-password-navigate-action"},
     {"test": "acme-email-password-checkbox"},
+    {"test": "acme-email-password-lastname-overlay"},
+    {"test": "acme-email-password-overlay"},
+    {"test": "acme-email-password"},
+    {"test": "acme-email-then-otp-multi-inputs"},
+    {"test": "acme-email-then-otp"},
+    {"test": "acme-email-then-password-labels"},
+    {"test": "acme-email-then-password-long-delay"},
+    {"test": "acme-email-then-password-then-mfa"},
+    {"test": "acme-email-then-password"},
+    {"test": "acme-email-validation-and-password"},
+    {"test": "universal-error-page"},
 ]
 
 
@@ -73,6 +85,10 @@ def test_auth_api_flow(test_case: dict[str, str]):
                     inputs[prompt_name] = os.environ.get("CNN_USERNAME", "") if brand_id == "cnn" else VALID_EMAIL
                 elif prompt_name == "password":
                     inputs[prompt_name] = os.environ.get("CNN_PASSWORD", "") if brand_id == "cnn" else VALID_PASSWORD
+                elif prompt_name == "lastname":
+                    inputs[prompt_name] = VALID_LASTNAME
+                elif prompt_name == "otp":
+                    inputs[prompt_name] = VALID_OTP
 
         state["inputs"] = inputs
         state["inputs"]["submit"] = "true"

--- a/tests/connectors/brand_specs/acme-email-and-password-navigate-action.yml
+++ b/tests/connectors/brand_specs/acme-email-and-password-navigate-action.yml
@@ -1,0 +1,43 @@
+# This is to test the specific case where we need to navigate to a different page after authenticating to verify
+# the authentication was successful.
+
+name: ACME
+
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: input[type=email]
+    - name: password
+      type: password
+      prompt: Please enter your password
+      selector: input[type=password]
+    - name: submit
+      type: click
+      selector: form button[type=submit]
+      prompt: Submit
+    - name: wait_for_sign_in
+      type: wait
+      selector: p:has-text("Welcome")
+    - name: navigate_to_verify
+      type: navigate
+      prompt: Navigate to verify
+      url: http://localhost:5001/verify
+      expect_nav: true
+    - name: account_verified
+      type: wait
+      selector: p:has-text("Account verified")
+  pages:
+    - name: Log in to ACME Corp
+      url: http://localhost:5001/auth/email-and-password
+      fields: [email, password, submit]
+
+    - name: Navigate to the next page
+      url: http://localhost:5001/submit/email-and-password
+      fields: [navigate_to_verify]
+
+    - name: Wait for the account verification page to load
+      fields: [account_verified]
+      end: true
+  start: Log in to ACME Corp

--- a/tests/connectors/brand_specs/acme-email-password-lastname-overlay.yml
+++ b/tests/connectors/brand_specs/acme-email-password-lastname-overlay.yml
@@ -1,0 +1,46 @@
+name: ACME
+
+auth:
+  fields:
+    - name: trigger_overlay
+      type: click
+      prompt: Trigger overlay
+      selector: button[onclick="toggleOverlay()"]
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: .overlay-form input[type=email]
+    - name: password
+      type: password
+      prompt: Please enter your password
+      selector: .overlay-form input[type=password]
+    - name: lastname
+      type: text
+      prompt: Please enter your last name
+      selector: .overlay-form input[name=lastname]
+    - name: submit
+      type: click
+      selector: .overlay-form button[type=submit]
+      prompt: Submit
+      expect_nav: true
+    - name: home_page
+      type: wait
+      selector: p:has-text("Welcome")
+    - name: overlay_active
+      type: wait
+      selector: .overlay.active
+  pages:
+    - name: Navigate to ACME Corp overlay login
+      url: http://localhost:5001/auth/email-password-lastname-overlay
+      fields: [trigger_overlay]
+
+    - name: Wait for overlay and fill in credentials
+      fields: [overlay_active, email]
+
+    - name: Fill last name
+      fields: [lastname, password, submit]
+
+    - name: Wait for sign-in to complete
+      fields: [home_page]
+      end: true
+  start: Navigate to ACME Corp overlay login

--- a/tests/connectors/brand_specs/acme-email-password-overlay.yml
+++ b/tests/connectors/brand_specs/acme-email-password-overlay.yml
@@ -1,0 +1,39 @@
+name: ACME
+
+auth:
+  fields:
+    - name: trigger_overlay
+      type: click
+      prompt: Trigger overlay
+      selector: button[onclick="toggleOverlay()"]
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: .overlay-form input[type=email]
+    - name: password
+      type: password
+      prompt: Please enter your password
+      selector: .overlay-form input[type=password]
+    - name: submit
+      type: click
+      prompt: Submit
+      selector: .overlay-form button[type=submit]
+      expect_nav: true
+    - name: welcome
+      type: wait
+      selector: p:has-text("Welcome")
+  pages:
+    - name: Navigate to ACME Corp overlay login
+      url: http://localhost:5001/auth/email-password-overlay
+      fields: [trigger_overlay]
+
+    - name: fill in credentials
+      timeout: 5
+      fields: [email, password, submit]
+
+    - name: Wait for sign-in to complete
+      timeout: 15
+      fields: [welcome]
+      end: true
+
+  start: Navigate to ACME Corp overlay login

--- a/tests/connectors/brand_specs/acme-email-password.yml
+++ b/tests/connectors/brand_specs/acme-email-password.yml
@@ -1,0 +1,29 @@
+name: ACME
+
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: input[type=email]
+    - name: password
+      type: password
+      prompt: Please enter your password
+      selector: input[type=password]
+    - name: submit
+      type: click
+      prompt: Submit
+      selector: form button[type=submit]
+      expect_nav: true
+    - name: welcome
+      type: wait
+      selector: p:has-text("Welcome")
+  pages:
+    - name: Log in to ACME Corp
+      url: http://localhost:5001/auth/email-and-password
+      fields: [email, password, submit]
+
+    - name: Wait for sign-in to complete
+      fields: [welcome]
+      end: true
+  start: Log in to ACME Corp

--- a/tests/connectors/brand_specs/acme-email-then-otp-multi-inputs.yml
+++ b/tests/connectors/brand_specs/acme-email-then-otp-multi-inputs.yml
@@ -1,0 +1,32 @@
+name: ACME
+
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: input[type=email]
+    - name: otp
+      type: text
+      prompt: Please enter the one-time code
+      selectors: input[name^="otp_"]
+    - name: submit
+      type: click
+      prompt: Submit
+      selector: form button[type=submit]
+      expect_nav: true
+    - name: welcome_page
+      type: wait
+      selector: p:has-text("Welcome")
+  pages:
+    - name: Go to ACME Corp
+      url: http://localhost:5001/auth/email-then-otp-multi-inputs
+      fields: [email, submit]
+
+    - name: OTP form
+      fields: [otp, submit]
+
+    - name: Welcome page
+      fields: [welcome_page]
+      end: true
+  start: Go to ACME Corp

--- a/tests/connectors/brand_specs/acme-email-then-otp.yml
+++ b/tests/connectors/brand_specs/acme-email-then-otp.yml
@@ -1,0 +1,34 @@
+name: ACME
+
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: input[type=email]
+    - name: otp
+      type: text
+      prompt: Please enter the one-time code
+      selector: input[type=text]
+    - name: submit
+      type: click
+      prompt: Submit
+      selector: form button[type=submit]
+      expect_nav: true
+    - name: welcome
+      type: wait
+      selector: p:has-text("Welcome")
+  pages:
+    - name: Go to ACME Corp
+      url: http://localhost:5001/auth/email-then-otp
+      fields: [email, submit]
+
+    - name: Wait for the OTP form
+      timeout: 5
+      fields: [otp, submit]
+
+    - name: Wait for sign-in to complete
+      timeout: 15
+      fields: [welcome]
+      end: true
+  start: Go to ACME Corp

--- a/tests/connectors/brand_specs/acme-email-then-password-labels.yml
+++ b/tests/connectors/brand_specs/acme-email-then-password-labels.yml
@@ -1,0 +1,34 @@
+name: ACME
+
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: input[type=email]
+    - name: password
+      type: password
+      prompt: Please enter your password
+      label: label:has-text("Pass")
+      selector: input[type=password]
+    - name: submit
+      type: click
+      prompt: Submit
+      selector: form button[type=submit]
+      expect_nav: true
+    - name: welcome
+      type: wait
+      selector: p:has-text("Welcome")
+  pages:
+    - name: Email form
+      url: http://localhost:5001/auth/email-then-password
+      fields: [email, submit]
+
+    - name: Password form
+      fields: [password, submit]
+
+    - name: Welcome page
+      fields: [welcome]
+      end: true
+
+  start: Email form

--- a/tests/connectors/brand_specs/acme-email-then-password-long-delay.yml
+++ b/tests/connectors/brand_specs/acme-email-then-password-long-delay.yml
@@ -1,0 +1,33 @@
+name: ACME
+
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: input[type=email]
+    - name: password
+      type: password
+      prompt: Please enter your password
+      selector: input[type=password]
+    - name: submit
+      type: click
+      prompt: Submit
+      selector: form button[type=submit]
+      expect_nav: true
+    - name: welcome
+      type: wait
+      selector: p:has-text("Welcome")
+  pages:
+    - name: Email form
+      url: http://localhost:5001/auth/email-then-password-long-delay
+      fields: [email, submit]
+
+    - name: Password form
+      fields: [password, submit]
+
+    - name: Welcome page
+      fields: [welcome]
+      end: true
+
+  start: Email form

--- a/tests/connectors/brand_specs/acme-email-then-password-then-mfa.yml
+++ b/tests/connectors/brand_specs/acme-email-then-password-then-mfa.yml
@@ -1,0 +1,39 @@
+name: ACME
+
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: input[type=email]
+    - name: password
+      type: password
+      prompt: Please enter your password
+      selector: input[type=password]
+    - name: submit
+      type: click
+      prompt: Submit
+      selector: form button[type=submit]
+      expect_nav: true
+    - name: otp
+      type: text
+      prompt: Please enter the one-time code
+      selector: input[type=text]
+    - name: welcome_page
+      type: wait
+      selector: p:has-text("Welcome")
+  pages:
+    - name: Go to ACME Corp
+      url: http://localhost:5001/auth/email-then-password-then-mfa
+      fields: [email, submit]
+
+    - name: Password form
+      fields: [password, submit]
+
+    - name: OTP form
+      fields: [otp, submit]
+
+    - name: Welcome page
+      fields: [welcome_page]
+      end: true
+  start: Go to ACME Corp

--- a/tests/connectors/brand_specs/acme-email-then-password.yml
+++ b/tests/connectors/brand_specs/acme-email-then-password.yml
@@ -1,0 +1,40 @@
+name: ACME
+
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Please enter your email address
+      selector: input[type=email]
+    - name: password
+      type: password
+      prompt: Please enter your password
+      selector: input[type=password]
+    - name: submit
+      type: click
+      prompt: Submit
+      selector: form button[type=submit]
+      expect_nav: true
+    - name: wrong_password_message
+      type: message
+      prompt: Incorrect credentials
+      label: p:has-text("Incorrect credentials")
+      selector: p:has-text("Incorrect credentials")
+    - name: welcome
+      type: wait
+      selector: p:has-text("Welcome")
+  pages:
+    - name: Email form
+      url: http://localhost:5001/auth/email-then-password
+      fields: [email, submit]
+
+    - name: Password form
+      fields:
+        required: [password, submit]
+        optional: [wrong_password_message]
+
+    - name: Welcome page
+      fields: [welcome]
+      end: true
+
+  start: Email form

--- a/tests/connectors/brand_specs/acme-email-validation-and-password.yml
+++ b/tests/connectors/brand_specs/acme-email-validation-and-password.yml
@@ -1,0 +1,33 @@
+name: ACME
+
+auth:
+  fields:
+    - name: email
+      type: text
+      prompt: Email address
+      selector: input[type=email]
+    - name: password
+      type: password
+      prompt: Password
+      selector: input[type=password]
+    - name: submit
+      type: click
+      prompt: Submit
+      selector: button[type=submit]
+    - name: welcome
+      type: wait
+      selector: p:has-text("Welcome")
+
+  pages:
+    - name: Fill in email
+      url: http://localhost:5001/auth/email-validation-and-password
+      fields: [email]
+
+    - name: Fill in password
+      fields: [password, submit]
+
+    - name: Wait for sign-in to complete
+      fields: [welcome]
+      end: true
+
+  start: Fill in email

--- a/tests/connectors/brand_specs/universal-error-page.yml
+++ b/tests/connectors/brand_specs/universal-error-page.yml
@@ -1,0 +1,23 @@
+name: Universal Error Page
+
+auth:
+  fields:
+    - name: signin_button
+      type: click
+      prompt: Sign In
+      selector: button[data-testid="signin-button"]
+
+    - name: message
+      type: wait
+      selector: p:has-text("Success")
+
+  pages:
+    - name: Sign in
+      url: http://localhost:5001/universal-error-test
+      fields: [signin_button]
+
+    - name: Wait for message
+      fields: [message]
+      end: true
+
+  start: Sign in


### PR DESCRIPTION
Adds to the existing ACME Corp server several new login type tests based on real world scenarios. These are so we can accurately test our auth orchestrator's ability to follow different kinds of yamls pertaining to login scenarios that occur in the wild.

There are 12 new ACME-based tests in this PR, with more complicated ones on the way. These are simply ported over from an existing private repository where these have existed in the past. They will run on every PR to ensure changes do not affect our ability to successfully complete these login types.

Next step will be to port over the more complicated tests.

To run them, ensure both the API and ACME servers are running, then run `uv run pytest -n 7 -m "api" tests/api/test_auth_api.py`

To run an individual test simply add `-k "acme-email-then-otp" -v` to the previous command.