### PR TITLE
Deploy to Google Cloud VM with Tailscale

### DIFF
--- a/.github/workflows/deploy-getgather-dev-tailscale.yml
+++ b/.github/workflows/deploy-getgather-dev-tailscale.yml
@@ -1,0 +1,34 @@
+name: Deploy to GetGather GCE Dev on Tailscale
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Show 5 most recent commits
+        run: git log --oneline -n 5
+
+      - name: Deploy to GCE via dokku
+        uses: dokku/github-action@master
+        with:
+          trace: 1
+          branch: main
+          git_push_flags: --force
+          git_remote_url: ${{ secrets.DEV_TAILSCALE_GCE_GIT_REMOTE_URL }}
+          ssh_host_key: ${{ secrets.DEV_TAILSCALE_GCE_SSH_HOST_KEY }}
+          ssh_private_key: ${{ secrets.DEV_TAILSCALE_GCE_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
Deploy script and secrets added to deploy the the app to the VM with Tailscale on it. I'll monitor this closely to see if it's deployed properly, and I'll also be removing it from the other repo for the time being, so they don't overlap.