### PR TITLE
Tailscale on Github Actions

### DIFF
--- a/.github/workflows/deploy-dokku.yml
+++ b/.github/workflows/deploy-dokku.yml
@@ -23,6 +23,14 @@ jobs:
       - name: Show 5 most recent commits
         run: git log --oneline -n 5
 
+      - name: Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          use-cache: true
+
       - name: Deploy to GCE via dokku
         uses: dokku/github-action@master
         with:


### PR DESCRIPTION
Added a tailscale step to our github actions deploy workflow so that we don't have to use the public IP for the VM. Once this works we can set a firewall to block incoming traffic on SSH port 22 (the default port for dokku I think).