### PR TITLE
Run VNC server on docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN apt-get update && apt-get install -y \
     fonts-liberation \
     libu2f-udev \
     libvulkan1 \
+    xfce4 \
+    xfce4-goodies \
+    x11vnc \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
@@ -68,6 +71,9 @@ ENV PYTHONUNBUFFERED=1 \
 ENV PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 
+# port for FastAPI server
 EXPOSE 8000
+# port for VNC server
+EXPOSE 5900
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ docker build -t getgather .
 docker run -p 8000:8000 --name getgather -d getgather
 ```
 
+Optionally, if you want to live stream the container desktop, run docker with additional parameters
+```bash
+-e VNC_PASSWORD=$YOUR_VNC_PASSWORD -p 5900:5900
+```
+
+
+
 and then navigate to `http://localhost:8000/docs` to see the API docs.
 
 All additional documentation is located in the [docs](./docs) directory:
@@ -59,3 +66,12 @@ For Claude Desktop (also works for Cursor)
   }
 }
 ```
+
+## Live stream container desktop 
+
+On MacOS
+- Open `Finder -> Go -> Connect to Server...`
+- Enter Server Address `vnc://localhost:5900`
+- Enter password `$YOUR_VNC_PASSWORD`, which is set at `docker run`
+
+You can use other VNC clients in a similar way.

--- a/README.md
+++ b/README.md
@@ -9,15 +9,12 @@
 docker build -t getgather .
 docker run -p 8000:8000 --name getgather -d getgather
 ```
+and then navigate to `http://localhost:8000/docs` to see the API docs.
 
 Optionally, if you want to live stream the container desktop, run docker with additional parameters
 ```bash
 -e VNC_PASSWORD=$YOUR_VNC_PASSWORD -p 5900:5900
 ```
-
-
-
-and then navigate to `http://localhost:8000/docs` to see the API docs.
 
 All additional documentation is located in the [docs](./docs) directory:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,33 @@
 #!/bin/sh
 set -e
 
-Xvfb :99 -screen 0 1920x1080x24 & export DISPLAY=:99 && /opt/venv/bin/python -m uvicorn getgather.api.main:app --host 0.0.0.0 --port 8000 --log-level debug
+# Start Xvfb display server
+Xvfb :99 -screen 0 1920x1080x24 >/dev/null 2>&1 &
+export DISPLAY=:99
+
+# Start Xfce desktop and VNC server
+startxfce4 >/dev/null 2>&1 &
+
+# Start VNC server only if VNC_PASSWORD is set
+if [ -n "$VNC_PASSWORD" ]; then
+    # Create VNC password file
+    mkdir -p /root/.vnc
+    x11vnc -storepasswd "$VNC_PASSWORD" /root/.vncpass
+
+    # Start x11vnc
+    x11vnc \
+        -forever \
+        -usepw \
+        -rfbport 5900 \
+        -display :99 \
+        -rfbauth /root/.vncpass \
+        -listen 0.0.0.0 \
+        -quiet \
+        -no6 >/dev/null 2>&1 &
+    echo "VNC server started on port 5900"
+else
+    echo "VNC_PASSWORD not set, VNC server not started"
+fi
+
+# Start FastAPI server
+/opt/venv/bin/python -m uvicorn getgather.api.main:app --host 0.0.0.0 --port 8000 --log-level debug


### PR DESCRIPTION
Run VNC server on the container to help with debugging

The server is optional and requires VNC_PASSWORD env variable to be set at `docker run`