### PR TITLE
Container: alternative faster way to install uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Stage 1: Builder
 FROM python:3.13-slim AS builder
 
+COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /uvx /bin/
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
-    && curl -Ls https://astral.sh/uv/install.sh | sh \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/.local/bin:$PATH"


### PR DESCRIPTION
As suggested in the documentation:
https://docs.astral.sh/uv/guides/integration/docker/#installing-uv

This is also better, since it doesn't rely on downloading and executing the install script every single time.