### PR TITLE
Container: favor jwm instead of the heavier XFCE4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,9 @@ RUN apt-get update && apt-get install -y \
     fonts-liberation \
     libu2f-udev \
     libvulkan1 \
-    xfce4 \
-    xfce4-goodies \
     x11vnc \
+    jwm \
+    x11-apps \
     dbus \
     dbus-x11 \
     --no-install-recommends && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,8 @@ while [ ! -e /tmp/.X11-unix/X99 ]; do
 done
 echo "Xvfb running on DISPLAY=$DISPLAY"
 
-# Start Xfce desktop and VNC server
-echo "Starting Xfce desktop environment..."
-startxfce4 >/dev/null 2>&1 &
+echo "Starting JWM (Joe's Window Manager)"
+jwm >/dev/null 2>&1 &
 
 # Start VNC server only if VNC_PASSWORD is set
 if [ -n "$VNC_PASSWORD" ]; then


### PR DESCRIPTION
Joe's Window Manager, used in many small Linux distributions like Puppy or DSL, is notoriously lightweight (3 MB idle). Prefer that instead of XFCE4 (reported to consume 70 MB just when idle).

https://joewing.net/projects/jwm/

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/71a86c51-4e3b-4a4a-979c-b888f474becb" />
