### PR TITLE
Container: use noVNC web-based VNC client for remove view

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,10 +55,14 @@ RUN apt-get update && apt-get install -y \
     x11-apps \
     dbus \
     dbus-x11 \
+    novnc \
+    websockify \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+
+RUN ln -s /usr/share/novnc/vnc_lite.html /usr/share/novnc/index.html
 
 COPY --from=builder /app/.venv /opt/venv
 COPY --from=builder /app/getgather /app/getgather
@@ -78,5 +82,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 EXPOSE 8000
 # port for VNC server
 EXPOSE 5900
+# port for noVNC web client
+EXPOSE 6080
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ docker run -p 8000:8000 --name getgather -d getgather
 ```
 and then navigate to `http://localhost:8000/docs` to see the API docs.
 
-Optionally, if you want to live stream the container desktop, run docker with additional parameters
+Optionally, if you want to live stream the container desktop, run it with additional parameters:
+
 ```bash
--e VNC_PASSWORD=$YOUR_VNC_PASSWORD -p 5900:5900
+-e VNC_PASSWORD=$YOUR_VNC_PASSWORD -p 6080:6080
 ```
+
+and then open `localhost:6080` with a web browser.
 
 All additional documentation is located in the [docs](./docs) directory:
 
@@ -63,12 +66,3 @@ For Claude Desktop (also works for Cursor)
   }
 }
 ```
-
-## Live stream container desktop 
-
-On MacOS
-- Open `Finder -> Go -> Connect to Server...`
-- Enter Server Address `vnc://localhost:5900`
-- Enter password `$YOUR_VNC_PASSWORD`, which is set at `docker run`
-
-You can use other VNC clients in a similar way.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,8 @@ if [ -n "$VNC_PASSWORD" ]; then
         -quiet \
         -no6 >/dev/null 2>&1 &
     echo "VNC server started on port 5900"
+    websockify --web /usr/share/novnc/ 6080 localhost:5900 &
+    echo "noVNC viewer started on port 6080"
 else
     echo "VNC_PASSWORD not set, VNC server not started"
 fi


### PR DESCRIPTION
To verify, build and run the container image using Podman or Docker:

```bash
podman build -t getgather .
podman run -p 8000:8000 --rm -e VNC_PASSWORD=secret -p 6080:6080 getgather
```

(Note the lack of mapping for port 5900 for VNC).

Then simply open `localhost:6080` with a web browser.

<img width="1970" height="1424" alt="image" src="https://github.com/user-attachments/assets/b4d04ab5-0c63-4bf2-9ca7-57c07e572455" />
